### PR TITLE
fix: correct error message formatting in PNG writer

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func generateVisualization(resp PrometheusResponse, title string) (*bytes.Buffer
 	buffer := bytes.NewBuffer([]byte{})
 	writer, err := p.WriterTo(width, height, "png") // Use the 16:9 aspect ratio
 	if err != nil {
-		return nil, fmt.Errorf("failed to create PNG writer:-? %v", err)
+		return nil, fmt.Errorf("failed to create PNG writer: %v", err)
 	}
 
 	_, err = writer.WriteTo(buffer)


### PR DESCRIPTION
Update the error message in the PNG writer creation to remove an  unnecessary character. This improves clarity and maintains a consistent  format for error reporting.