### PR TITLE
feat(release): create draft releases and validate build success

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      release_id: ${{ steps.semantic.outputs.release_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,6 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: main
+          draft: true # Create release as draft initially
           extra_plugins: |
             @semantic-release/git
             @semantic-release/changelog
@@ -60,6 +62,8 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
+    outputs:
+      build_success: ${{ steps.build-status.outputs.success }}
 
     steps:
       - name: Checkout repository
@@ -111,23 +115,46 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && needs.release.outputs.new_release_published == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+      - name: Set build status
+        id: build-status
+        if: success()
+        run: echo "success=true" >> $GITHUB_OUTPUT
+
+  validate-release:
+    needs: [release, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: needs.release.outputs.new_release_published == 'true'
+    steps:
+      - name: Publish or rollback release
         env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.release.outputs.release_id }}
+        run: |
+          if [[ "${{ needs.build.outputs.build_success }}" == "true" ]]; then
+            # Publish the release
+            gh api \
+              --method PATCH \
+              /repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }} \
+              -f draft=false
+          else
+            # Delete the draft release and tag
+            gh api \
+              --method DELETE \
+              /repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}
+            git push --delete origin v${{ needs.release.outputs.new_release_version }}
+          fi
+
+      - name: Sign the published Docker image
+        if: needs.build.outputs.build_success == 'true'
+        env:
+          TAGS: ${{ needs.meta.outputs.tags }}
+          DIGEST: ${{ needs.build.outputs.digest }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -106,6 +106,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ needs.release.outputs.new_release_version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.new_release_version }}
             type=semver,pattern={{major}},value=${{ needs.release.outputs.new_release_version }}
+            type=raw,value=rc,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
@@ -158,3 +159,65 @@ jobs:
           TAGS: ${{ needs.meta.outputs.tags }}
           DIGEST: ${{ needs.build.outputs.digest }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  promote-to-rc:
+    needs: [validate-release, build]
+    runs-on: ubuntu-latest
+    if: |
+      needs.build.outputs.build_success == 'true' &&
+      needs.release.outputs.new_release_published == 'true' &&
+      github.ref == 'refs/heads/main'
+    steps:
+      - name: Login to Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote to RC
+        run: |
+          # Pull the new version
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.release.outputs.new_release_version }}
+          # Tag as RC
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.release.outputs.new_release_version }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rc
+          # Push RC tag
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rc
+
+  promote-to-stable:
+    needs: [validate-release, build]
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: write
+      packages: write
+    # Manual trigger via environment protection rule
+    if: |
+      needs.build.outputs.build_success == 'true' &&
+      needs.release.outputs.new_release_published == 'true'
+    steps:
+      - name: Login to Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote to Stable
+        run: |
+          # Pull the release version
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.release.outputs.new_release_version }}
+          # Tag as stable
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ needs.release.outputs.new_release_version }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable
+          # Push stable tag
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable
+
+      - name: Update Release Notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ needs.release.outputs.release_id }}
+        run: |
+          gh api \
+            --method PATCH \
+            /repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }} \
+            -f body="This version has been promoted to production (stable)"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,6 +64,8 @@ jobs:
       id-token: write
     outputs:
       build_success: ${{ steps.build-status.outputs.success }}
+      image_tags: ${{ steps.meta.outputs.tags }}
+      image_digest: ${{ steps.build-and-push.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -156,8 +158,8 @@ jobs:
       - name: Sign the published Docker image
         if: needs.build.outputs.build_success == 'true'
         env:
-          TAGS: ${{ needs.meta.outputs.tags }}
-          DIGEST: ${{ needs.build.outputs.digest }}
+          TAGS: ${{ needs.build.outputs.image_tags }}
+          DIGEST: ${{ needs.build.outputs.image_digest }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
   promote-to-rc:


### PR DESCRIPTION
Create releases as drafts initially to allow for validation before  publishing. Update the Docker image push condition to only occur  if a new release is published and the build is successful. Add a  new job to handle the publishing or rollback of the release based  on the build status, ensuring better control over the release  process.