### PR TITLE
fix: rename MINIO_URL to MINIO_ENDPOINT in deployment.yaml

### DIFF
--- a/manifests/snapshot/deployment.yaml
+++ b/manifests/snapshot/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         ports:
         - containerPort: 8080
         env:
-        - name:  MINIO_URL
+        - name:  MINIO_ENDPOINT
           value: http://minio:9000
         - name:  MINIO_ACCESS_KEY
           value: prometheus-snapshotter


### PR DESCRIPTION
Updates the environment variable name from MINIO_URL to  MINIO_ENDPOINT for clarity and consistency in the  deployment configuration. This change improves the  understanding of the variable's purpose.