### PR TITLE
feat: add MinioBucket configuration to support dynamic bucket

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ type Config struct {
 	MinioAccessKey string
 	MinioSecretKey string
 	MinioUseSSL    bool
+	MinioBucket    string
 }
 
 func loadConfig() (*Config, error) {
@@ -36,7 +37,8 @@ func loadConfig() (*Config, error) {
 		MinioEndpoint:  getEnvOrDefault("MINIO_ENDPOINT", "localhost:9000"),
 		MinioAccessKey: getEnvOrDefault("MINIO_ACCESS_KEY", "minioadmin"),
 		MinioSecretKey: getEnvOrDefault("MINIO_SECRET_KEY", "minioadmin"),
-		MinioUseSSL:    func() bool {
+		MinioBucket:    getEnvOrDefault("MINIO_BUCKET", "prometheus-snapshots"),
+		MinioUseSSL: func() bool {
 			if value, err := strconv.ParseBool(os.Getenv("MINIO_USE_SSL")); err == nil {
 				return value
 			}
@@ -202,8 +204,8 @@ func uploadToMinIO(img *bytes.Buffer, title string, r *http.Request) (string, er
 		return "", fmt.Errorf("failed to initialize MinIO client: %v", err)
 	}
 
-	// Define bucket and object name
-	bucketName := "visualizations"
+	// Use the configured bucket name
+	bucketName := config.MinioBucket
 	objectName := fmt.Sprintf("%s-%s.png", title, uuid.New().String())
 
 	// Ensure the bucket exists

--- a/manifests/snapshot/deployment.yaml
+++ b/manifests/snapshot/deployment.yaml
@@ -18,17 +18,17 @@ spec:
         ports:
         - containerPort: 8080
         env:
-        - name:  MINIO_ENDPOINT
+        - name: MINIO_ENDPOINT
           value: http://minio:9000
-        - name:  MINIO_ACCESS_KEY
+        - name: MINIO_ACCESS_KEY
           value: prometheus-snapshotter
-        - name:  MINIO_SECRET_KEY
+        - name: MINIO_SECRET_KEY
           value: 9aa5782a-9e0c-4396-99ae-c8955f03f88c
-        - name:  MINIO_BUCKET
+        - name: MINIO_BUCKET
           value: prometheus-snapshots
-        - name:  MinioUseSSL
+        - name: MINIO_USE_SSL
           value: "false"
-        - name:  PROMETHEUS_URL
+        - name: PROMETHEUS_URL
           value: http://prometheus-k8s.monitoring:9090
         resources:
           requests:


### PR DESCRIPTION
Add MinioBucket field to Config struct for dynamic bucket  configuration. Update environment variable names in deployment  YAML for consistency. Modify upload function to use the  configured bucket name instead of a hardcoded value. This  enhances flexibility and allows for easier configuration  management.