### PR TITLE
✨ fix: correct image pull policy in deployment.yaml

### DIFF
--- a/manifests/snapshot/deployment.yaml
+++ b/manifests/snapshot/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
       - name: prometheussnapshot
         image: ghcr.io/opscalehub/prometheussnapshot:main
-        pullPolicy: Always
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
Update the image pull policy from `pullPolicy` to  `imagePullPolicy` for the prometheussnapshot container  in the deployment configuration. This change ensures  consistency with Kubernetes specifications and avoids  potential deployment issues.